### PR TITLE
Update samples from MSAL .Net v3 to v4

### DIFF
--- a/base-console-app-cert/ConsoleGraphTest.csproj
+++ b/base-console-app-cert/ConsoleGraphTest.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/base-console-app/ConsoleGraphTest.csproj
+++ b/base-console-app/ConsoleGraphTest.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/day16-create-user/ConsoleGraphTest.csproj
+++ b/day16-create-user/ConsoleGraphTest.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/day17-assign-license/ConsoleGraphTest.csproj
+++ b/day17-assign-license/ConsoleGraphTest.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/day18-mailbox/ConsoleGraphTest.csproj
+++ b/day18-mailbox/ConsoleGraphTest.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/day19-assign-permissions/ConsoleGraphTest.csproj
+++ b/day19-assign-permissions/ConsoleGraphTest.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/day20-devicecode/ConsoleGraphTest.csproj
+++ b/day20-devicecode/ConsoleGraphTest.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/day20-devicecode/README.md
+++ b/day20-devicecode/README.md
@@ -143,7 +143,7 @@ At the time of the writing, the Device Code Flow flow is now implemented in GA v
     by
 
     ```xml
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" /> 
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" /> 
     ```
 
 1. In a command line type the following command `dotnet restore`.

--- a/day21-planner/ConsoleGraphTest.csproj
+++ b/day21-planner/ConsoleGraphTest.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/day22-intune/ConsoleGraphTest.csproj
+++ b/day22-intune/ConsoleGraphTest.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/day25-onenote/ConsoleGraphTest.csproj
+++ b/day25-onenote/ConsoleGraphTest.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/day28-webhooks/msgraph-webhook.csproj
+++ b/day28-webhooks/msgraph-webhook.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/dayNN-template/ConsoleGraphTest.csproj
+++ b/dayNN-template/ConsoleGraphTest.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
No code changes required after previous updates from v2.x to v3.  Only updating NuGet references in projects.